### PR TITLE
[feat] 댓글 조회 api 구현

### DIFF
--- a/src/main/java/com/bootcamp/introductmyteam/controller/CommentController.java
+++ b/src/main/java/com/bootcamp/introductmyteam/controller/CommentController.java
@@ -1,0 +1,27 @@
+package com.bootcamp.introductmyteam.controller;
+
+import com.bootcamp.introductmyteam.dto.response.CommentResponse;
+import com.bootcamp.introductmyteam.dto.response.CommentResponses;
+import com.bootcamp.introductmyteam.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/comments")
+@RestController
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @GetMapping("/{articleId}")
+    public ResponseEntity<CommentResponses> getComments(@PathVariable Long articleId) {
+        List<CommentResponse> commentResponses = commentService.findByArticleId(articleId);
+        return ResponseEntity.ok(CommentResponses.of(commentResponses));
+    }
+}

--- a/src/main/java/com/bootcamp/introductmyteam/controller/CommentController.java
+++ b/src/main/java/com/bootcamp/introductmyteam/controller/CommentController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RequiredArgsConstructor
-@RequestMapping("/api/comments")
+@RequestMapping("/comments")
 @RestController
 public class CommentController {
 

--- a/src/main/java/com/bootcamp/introductmyteam/domain/Article.java
+++ b/src/main/java/com/bootcamp/introductmyteam/domain/Article.java
@@ -1,0 +1,15 @@
+package com.bootcamp.introductmyteam.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+@Getter
+@Entity
+public class Article {
+
+    @GeneratedValue
+    @Id
+    private Long id;
+}

--- a/src/main/java/com/bootcamp/introductmyteam/domain/Comment.java
+++ b/src/main/java/com/bootcamp/introductmyteam/domain/Comment.java
@@ -1,0 +1,35 @@
+package com.bootcamp.introductmyteam.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Getter
+@Entity
+public class Comment {
+
+    @GeneratedValue
+    @Id
+    private Long id;
+
+    private String content;
+
+    private String nickname;
+
+    private String password;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Article article;
+
+    protected Comment() {}
+
+    private Comment(String content, String nickname, String password, Article article) {
+        this.content = content;
+        this.nickname = nickname;
+        this.password = password;
+        this.article = article;
+    }
+
+    public static Comment of(String content, String nickname, String password, Article article) {
+        return new Comment(content, nickname, password, article);
+    }
+}

--- a/src/main/java/com/bootcamp/introductmyteam/dto/response/CommentResponse.java
+++ b/src/main/java/com/bootcamp/introductmyteam/dto/response/CommentResponse.java
@@ -1,0 +1,19 @@
+package com.bootcamp.introductmyteam.dto.response;
+
+import com.bootcamp.introductmyteam.domain.Comment;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class CommentResponse {
+
+    private String content;
+
+    private String nickname;
+
+    public static CommentResponse from(Comment comment) {
+        return new CommentResponse(comment.getContent(), comment.getNickname());
+    }
+}

--- a/src/main/java/com/bootcamp/introductmyteam/dto/response/CommentResponse.java
+++ b/src/main/java/com/bootcamp/introductmyteam/dto/response/CommentResponse.java
@@ -9,11 +9,13 @@ import lombok.Getter;
 @Getter
 public class CommentResponse {
 
+    private Long id;
+
     private String content;
 
     private String nickname;
 
     public static CommentResponse from(Comment comment) {
-        return new CommentResponse(comment.getContent(), comment.getNickname());
+        return new CommentResponse(comment.getId(), comment.getContent(), comment.getNickname());
     }
 }

--- a/src/main/java/com/bootcamp/introductmyteam/dto/response/CommentResponses.java
+++ b/src/main/java/com/bootcamp/introductmyteam/dto/response/CommentResponses.java
@@ -1,0 +1,17 @@
+package com.bootcamp.introductmyteam.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class CommentResponses {
+    private List<CommentResponse> commentResponses;
+
+    public static CommentResponses of(List<CommentResponse> commentResponses) {
+        return new CommentResponses(commentResponses);
+    }
+}

--- a/src/main/java/com/bootcamp/introductmyteam/repository/CommentRepository.java
+++ b/src/main/java/com/bootcamp/introductmyteam/repository/CommentRepository.java
@@ -1,0 +1,14 @@
+package com.bootcamp.introductmyteam.repository;
+
+import com.bootcamp.introductmyteam.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @Query("SELECT c FROM Comment c WHERE c.article.id = :articleId ORDER BY c.id DESC")
+    List<Comment> findByArticleIdOrderByIdDesc(@Param("articleId") Long articleId);
+}

--- a/src/main/java/com/bootcamp/introductmyteam/service/CommentService.java
+++ b/src/main/java/com/bootcamp/introductmyteam/service/CommentService.java
@@ -1,0 +1,22 @@
+package com.bootcamp.introductmyteam.service;
+
+import com.bootcamp.introductmyteam.dto.response.CommentResponse;
+import com.bootcamp.introductmyteam.repository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+
+    public List<CommentResponse> findByArticleId(Long articleId) {
+        return commentRepository.findByArticleIdOrderByIdDesc(articleId).stream().map(CommentResponse::from).toList();
+    }
+
+}


### PR DESCRIPTION
파라미터로 게시글의 id를 받아서 db 에서 해당 게시글의 댓글들을 조회하는 api를 구현했습니다.

`CommentContrller` -> `CommentService` -> `CommentRepository` 순으로 요청이 흘러가서 db 에서 댓글들을 가져오도록 구현했습니다.
* 최신 댓글부터 보기위해 id 의 역순으로 가져오도록 했습니다.

`Article`, `Comment` 와 같은 도메인 코드들의 기본 생성자는  제어자를 `protected`로 둬서 제한하고 static method 인 `of` 로만 생성할 수 있도록 구현했습니다.

`api/comments/{articleId}` 를 `GET` 요청 시 `id`, `content`, `nickname` 을 받을 수 있습니다.