### PR TITLE
[feat] 댓글 수정, 삭제 api 구현

### DIFF
--- a/src/main/java/com/bootcamp/introductmyteam/controller/CommentController.java
+++ b/src/main/java/com/bootcamp/introductmyteam/controller/CommentController.java
@@ -1,6 +1,8 @@
 package com.bootcamp.introductmyteam.controller;
 
+import com.bootcamp.introductmyteam.dto.request.CommentDeleteRequest;
 import com.bootcamp.introductmyteam.dto.request.CommentRequest;
+import com.bootcamp.introductmyteam.dto.request.CommentUpdateRequest;
 import com.bootcamp.introductmyteam.dto.response.CommentResponse;
 import com.bootcamp.introductmyteam.dto.response.CommentResponses;
 import com.bootcamp.introductmyteam.service.CommentService;
@@ -8,10 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -33,8 +32,23 @@ public class CommentController {
     }
 
     @GetMapping("/{articleId}")
+    @ResponseBody
     public ResponseEntity<CommentResponses> getComments(@PathVariable Long articleId) {
         List<CommentResponse> commentResponses = commentService.findByArticleId(articleId);
         return ResponseEntity.ok(CommentResponses.of(commentResponses));
+    }
+
+    @PutMapping("/{commentId}")
+    @ResponseBody
+    public ResponseEntity<Void> updateComment(@PathVariable Long commentId, @RequestBody CommentUpdateRequest request) {
+        commentService.updateComment(commentId, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{commentId}")
+    @ResponseBody
+    public ResponseEntity<Void> deleteComment(@PathVariable Long commentId, @RequestBody CommentDeleteRequest deleteRequest) {
+        commentService.deleteComment(commentId, deleteRequest);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/bootcamp/introductmyteam/domain/Comment.java
+++ b/src/main/java/com/bootcamp/introductmyteam/domain/Comment.java
@@ -34,4 +34,8 @@ public class Comment {
     public static Comment of(String content, String nickname, String password, Article article) {
         return new Comment(content, nickname, password, article);
     }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/com/bootcamp/introductmyteam/dto/request/CommentDeleteRequest.java
+++ b/src/main/java/com/bootcamp/introductmyteam/dto/request/CommentDeleteRequest.java
@@ -1,0 +1,11 @@
+package com.bootcamp.introductmyteam.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CommentDeleteRequest {
+    private String password;
+}

--- a/src/main/java/com/bootcamp/introductmyteam/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/com/bootcamp/introductmyteam/dto/request/CommentUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.bootcamp.introductmyteam.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class CommentUpdateRequest {
+    private String content;
+    private String password;
+}

--- a/src/main/java/com/bootcamp/introductmyteam/service/CommentService.java
+++ b/src/main/java/com/bootcamp/introductmyteam/service/CommentService.java
@@ -2,7 +2,10 @@ package com.bootcamp.introductmyteam.service;
 
 import com.bootcamp.introductmyteam.domain.Article;
 import com.bootcamp.introductmyteam.domain.Comment;
+import com.bootcamp.introductmyteam.dto.request.CommentDeleteRequest;
 import com.bootcamp.introductmyteam.dto.request.CommentRequest;
+import com.bootcamp.introductmyteam.domain.Comment;
+import com.bootcamp.introductmyteam.dto.request.CommentUpdateRequest;
 import com.bootcamp.introductmyteam.dto.response.CommentResponse;
 import com.bootcamp.introductmyteam.repository.CommentRepository;
 import lombok.RequiredArgsConstructor;
@@ -40,5 +43,26 @@ public class CommentService {
     public List<CommentResponse> findByArticleId(Long articleId) {
         return commentRepository.findByArticleIdOrderByIdDesc(articleId).stream().map(CommentResponse::from).toList();
     }
+
+    @Transactional
+    public void updateComment(Long commentId, CommentUpdateRequest commentUpdateRequest) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow(RuntimeException::new);
+        validateAuthor(comment, commentUpdateRequest.getPassword());
+        comment.updateContent(commentUpdateRequest.getContent());
+    }
+
+    @Transactional
+    public void deleteComment(Long commentId, CommentDeleteRequest deleteRequest) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow(RuntimeException::new);
+        validateAuthor(comment, deleteRequest.getPassword());
+        commentRepository.delete(comment);
+    }
+
+    private void validateAuthor(Comment comment, String password) {
+        if (!comment.getPassword().equals(password)) {
+            throw new RuntimeException();
+        }
+    }
+
 
 }


### PR DESCRIPTION
* 댓글 수정, 삭제 api 를 구현했습니다.

* 댓글 수정
  * 인자로 경로 변수 `commentId` 를 받으며 json 데이터로 `String content`, `String password` 를 받습니다.

* 댓글 삭제
  * 인자로 경로 변수 `commentId` 를 받으며 json 데이터로 `String password` 를 받습니다.


* Postman 으로 잘 작동하는 것을 확인했습니다.